### PR TITLE
Fix typo in JP specific phosphor and out-of-bounds array access with custom gamuts

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -410,7 +410,7 @@ const double gamutpoints[19][3][3] = {
     {
         {0.618, 0.35, 0.032}, //red
         {0.29, 0.6, 0.11}, //green
-        {0.15, 0.06, 0.97} //blue
+        {0.15, 0.06, 0.79} //blue
     },
 
     // Sony PVM 20M2U (~1996) measured by Keith Raney

--- a/src/gamutthingy.cpp
+++ b/src/gamutthingy.cpp
@@ -2835,10 +2835,10 @@ int main(int argc, const char **argv){
     bool compressenabled = (mapmode >= MAP_FIRST_COMPRESS);
     
     gamutdescriptor sourcegamut;
-    bool srcOK = sourcegamut.initialize(gamutnames[sourcegamutindex], sourcewhite, sourcered, sourcegreen, sourceblue, destwhite, true, verbosity, adapttype, compressenabled, sourcegamutcrtsetting, &emulatedcrt);
+    bool srcOK = sourcegamut.initialize(sourcegamutindex != GAMUT_CUSTOM ? gamutnames[sourcegamutindex] : "Custom Source Gamut", sourcewhite, sourcered, sourcegreen, sourceblue, destwhite, true, verbosity, adapttype, compressenabled, sourcegamutcrtsetting, &emulatedcrt);
     
     gamutdescriptor destgamut;
-    bool destOK = destgamut.initialize(gamutnames[destgamutindex], destwhite, destred, destgreen, destblue, sourcewhite, false, verbosity, adapttype, compressenabled, destgamutcrtsetting, &emulatedcrt);
+    bool destOK = destgamut.initialize(destgamutindex != GAMUT_CUSTOM ? gamutnames[destgamutindex] : "Custom Destination Gamut", destwhite, destred, destgreen, destblue, sourcewhite, false, verbosity, adapttype, compressenabled, destgamutcrtsetting, &emulatedcrt);
     
     if ((mapmode == MAP_CCC_B) || (mapmode == MAP_CCC_C)){
         destgamut.initializeMatrixChunghwa(sourcegamut, verbosity);


### PR DESCRIPTION
All I've done here are a couple quick fixes, but maybe we should instead add some bigger refactoring and safety checking--for instance, adding functions to safely access these arrays and return alternative strings for custom gamuts/whitepoints/(de)modulators, changing the gamut definitions from arrays to structs with methods, adding a check for xyz not adding up to 1.0, etc. Currently, we have to manually check for typos, and we have to just remember to add in if-statements for every time a name string is needed.

As a side note, I've edited my previous message to include the model number of my RCA CRT. The model number is E13169GM.